### PR TITLE
implemented @-based reconnect, status, and health commands

### DIFF
--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Get current timestamp as f64 seconds since UNIX epoch with consistent precision
-fn current_timestamp() -> f64 {
+pub fn current_timestamp() -> f64 {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()


### PR DESCRIPTION
Implements a command interface using '@' as a sentinel.
Commands include:
- @reconnect
  - we can put this at the top of scripts so they auto-reconnect when run
- @status, @health
  - we can use these to more easily verify the daemon is up, and to debug connection issues

As most things here, this is 100% claudeware